### PR TITLE
addes https support for schema url

### DIFF
--- a/R/XBRL.R
+++ b/R/XBRL.R
@@ -29,17 +29,18 @@ XBRL <- function() {
   inst.lnkb <- NULL
   
   fixFileName <- function(dname, file.name) {
-    if (substr(file.name, 1, 5) != "http:") {
+    if (!(substr(file.name, 1, 6) %in% c("http:/", "https:"))) {
       if (substr(file.name, 1, 5) == "../..") { ## A better solution is preferred, but it works for now
         file.name <- paste0(dirname(dirname(dname)), "/",  substr(file.name, 7, nchar(file.name)))
       } else if (substr(file.name, 1, 2) == "..") {
-        file.name <- paste0(dirname(dname), "/", substr(file.name, 4, nchar(file.name)))
+          file.name <- paste0(dirname(dname), "/", substr(file.name, 4, nchar(file.name)))
       } else {
         file.name <- paste0(dname,"/", file.name)
       }
     }
     file.name
   }
+
 
   setVerbose <- function(newVerbose) {
     oldVerbose <- verbose


### PR DESCRIPTION
URL of Schemas were wrongly created and leaded to error and code stop

Call:
XBRL::xbrlDoAll(file.inst = "https://www.sec.gov/Archives/edgar/data/1082506/000156459018023113/gec-20180630.xml", verbose = TRUE)

Result:
Cannot open URL 'https://www.sec.gov/Archives/edgar/data/1082506/000156459018023113/https://xbrl.sec.gov/dei/2018/dei-2018-01-31.xsd'